### PR TITLE
UI for Preview, Change Scope, and more

### DIFF
--- a/LoveLiver-osx/AVKitExtension.swift
+++ b/LoveLiver-osx/AVKitExtension.swift
@@ -1,0 +1,45 @@
+//
+//  AVKitExtension.swift
+//  LoveLiver
+//
+//  Created by BAN Jun on 2016/03/20.
+//  Copyright © 2016年 mzp. All rights reserved.
+//
+
+import AVFoundation
+
+
+extension CMTime {
+    var msS: (Int, Int, Int) {
+        let duration = CMTimeGetSeconds(self)
+        let minutes = Int(floor(duration / 60))
+        let seconds = Int(floor(duration - Double(minutes) * 60))
+        let milliseconds = Int((duration - floor(duration)) * 100)
+        return (minutes, seconds, milliseconds)
+    }
+
+    var stringInmmssSS: String {
+        let (minutes, seconds, milliseconds) = msS
+        return String(format: "%02d:%02d.%02d", minutes, seconds, milliseconds)
+    }
+
+    var stringInmmmsssSS: String {
+        let (minutes, seconds, milliseconds) = msS
+        return String(format: "%02dm%02ds%02d", minutes, seconds, milliseconds)
+    }
+}
+
+
+extension AVAssetImageGenerator {
+    func copyImage(at time: CMTime) -> NSImage? {
+        guard let cgImage = try? copyCGImageAtTime(time, actualTime: nil) else { return nil }
+        return NSImage(CGImage: cgImage, size: CGSize(width: CGImageGetWidth(cgImage), height: CGImageGetHeight(cgImage)))
+    }
+}
+
+
+extension AVPlayerItem {
+    var naturalSize: CGSize? {
+        return asset.tracksWithMediaType(AVMediaTypeVideo).first?.naturalSize
+    }
+}

--- a/LoveLiver-osx/AVKitExtension.swift
+++ b/LoveLiver-osx/AVKitExtension.swift
@@ -18,6 +18,11 @@ extension CMTime {
         return (minutes, seconds, milliseconds)
     }
 
+    var stringInsSS: String {
+        let (minutes, seconds, milliseconds) = msS
+        return String(format: "%d.%02d", minutes * 60 + seconds, milliseconds)
+    }
+
     var stringInmmssSS: String {
         let (minutes, seconds, milliseconds) = msS
         return String(format: "%02d:%02d.%02d", minutes, seconds, milliseconds)
@@ -41,5 +46,9 @@ extension AVAssetImageGenerator {
 extension AVPlayerItem {
     var naturalSize: CGSize? {
         return asset.tracksWithMediaType(AVMediaTypeVideo).first?.naturalSize
+    }
+
+    var minFrameDuration: CMTime? {
+        return asset.tracksWithMediaType(AVMediaTypeVideo).first?.minFrameDuration
     }
 }

--- a/LoveLiver-osx/LivePhotoSandboxViewController.swift
+++ b/LoveLiver-osx/LivePhotoSandboxViewController.swift
@@ -78,19 +78,6 @@ class LivePhotoSandboxViewController: NSViewController {
         afterPosterLabel.stringValue = " ~ \(CMTimeSubtract(endTime, posterTime).stringInsSS) ~ "
         endLabel.stringValue = endTime.stringInmmssSS
     }
-    private lazy var startMinusButton: NSButton = NSButton() ※ self.button ※ { b in
-        b.title = "←"
-        b.action = "startMinus"
-    }
-    private lazy var endPlusButton: NSButton = NSButton() ※ self.button ※ { b in
-        b.title = "→"
-        b.action = "endPlus"
-    }
-    private func button(b: NSButton) {
-        b.setButtonType(.MomentaryLightButton)
-        b.bezelStyle = .RegularSquareBezelStyle
-        b.target = self
-    }
     private func updateScope() {
         overview.scopeRange = CMTimeRange(start: startTime, end: endTime)
     }
@@ -145,13 +132,11 @@ class LivePhotoSandboxViewController: NSViewController {
             "overview": overview,
             "startFrame": startFrameView,
             "startLabel": startLabel,
-            "startMinus": startMinusButton,
             "beforePosterLabel": beforePosterLabel,
             "posterLabel": posterLabel,
             "afterPosterLabel": afterPosterLabel,
             "endFrame": endFrameView,
             "endLabel": endLabel,
-            "endPlus": endPlusButton,
             "spacerLL": NSView(),
             "spacerLR": NSView(),
             "spacerRL": NSView(),
@@ -160,15 +145,14 @@ class LivePhotoSandboxViewController: NSViewController {
         autolayout("H:|-p-[player(>=300)]-p-|")
         autolayout("H:|-p-[startFrame]-(>=p)-[endFrame(==startFrame)]-p-|")
         autolayout("H:|-p-[startLabel][spacerLL][beforePosterLabel][spacerLR(==spacerLL)][posterLabel][spacerRL(==spacerLL)][afterPosterLabel][spacerRR(==spacerLL)][endLabel]-p-|")
-        autolayout("H:|-p-[startMinus]-(>=p)-[endPlus]-p-|")
         autolayout("H:|-p-[overview]-p-|")
         autolayout("V:|-p-[player(>=300)]")
         autolayout("V:[player][overview(==64)]")
-        autolayout("V:[overview]-p-[startFrame(==128)][startLabel][startMinus]-p-|")
+        autolayout("V:[overview]-p-[startFrame(==128)][startLabel]-p-|")
         autolayout("V:[startFrame][beforePosterLabel]")
         autolayout("V:[startFrame][posterLabel]")
         autolayout("V:[startFrame][afterPosterLabel]")
-        autolayout("V:[overview]-p-[endFrame(==startFrame)][endLabel][endPlus]-p-|")
+        autolayout("V:[overview]-p-[endFrame(==startFrame)][endLabel]-p-|")
 
         if let videoSize = player.currentItem?.naturalSize {
             playerView.addConstraint(NSLayoutConstraint(item: playerView, attribute: .Height, relatedBy: .Equal,
@@ -192,22 +176,6 @@ class LivePhotoSandboxViewController: NSViewController {
         // hook playerView click
         let playerViewClickGesture = NSClickGestureRecognizer(target: self, action: "playOrPause")
         playerView.addGestureRecognizer(playerViewClickGesture)
-    }
-
-    @objc private func startMinus() {
-        guard let item = player.currentItem,
-            let minFrameDuration = item.minFrameDuration else { return }
-        startTime = CMTimeSubtract(startTime, minFrameDuration)
-        endTime = CMTimeSubtract(endTime, minFrameDuration)
-        updateImages()
-    }
-
-    @objc private func endPlus() {
-        guard let item = player.currentItem,
-            let minFrameDuration = item.minFrameDuration else { return }
-        startTime = CMTimeAdd(startTime, minFrameDuration)
-        endTime = CMTimeAdd(endTime, minFrameDuration)
-        updateImages()
     }
 
     func onScopeChange(dragging: Bool) {

--- a/LoveLiver-osx/LivePhotoSandboxViewController.swift
+++ b/LoveLiver-osx/LivePhotoSandboxViewController.swift
@@ -130,6 +130,7 @@ class LivePhotoSandboxViewController: NSViewController {
         }
 
         overview = MovieOverviewControl(player: self.player, playerItem: item ?? AVPlayerItem(asset: AVAsset()))
+        overview.draggingMode = .Scope
         overview.imageGeneratorTolerance = kCMTimeZero
 
         super.init(nibName: nil, bundle: nil)
@@ -202,6 +203,7 @@ class LivePhotoSandboxViewController: NSViewController {
 
         let trimStart = CMTimeSubtract(posterTime, CMTime(seconds: livePhotoDuration, preferredTimescale: posterTime.timescale))
         overview.trimRange = CMTimeRange(start: trimStart, duration: CMTime(seconds: livePhotoDuration * 2, preferredTimescale: posterTime.timescale))
+        overview.onScopeChange = {[weak self] dragging in self?.onScopeChange(dragging)}
         updateScope()
     }
 
@@ -221,6 +223,17 @@ class LivePhotoSandboxViewController: NSViewController {
         endTime = CMTimeAdd(endTime, minFrameDuration)
         updateImages()
         updatePlayButton()
+    }
+
+    func onScopeChange(dragging: Bool) {
+        guard let s = overview.scopeRange?.start,
+            let e = overview.scopeRange?.end else { return }
+        startTime = s
+        endTime = e
+
+        if !dragging {
+            updateImages()
+        }
     }
 
     @objc private func play() {

--- a/LoveLiver-osx/LivePhotoSandboxViewController.swift
+++ b/LoveLiver-osx/LivePhotoSandboxViewController.swift
@@ -1,0 +1,152 @@
+//
+//  LivePhotoSandboxViewController.swift
+//  LoveLiver
+//
+//  Created by BAN Jun on 2016/03/21.
+//  Copyright © 2016年 mzp. All rights reserved.
+//
+
+import Cocoa
+import AVFoundation
+import AVKit
+import NorthLayout
+import Ikemen
+
+
+class LivePhotoSandboxViewController: NSViewController {
+    private let player: AVPlayer
+    private let playerView: AVPlayerView = AVPlayerView() ※ { v in
+        v.controlsStyle = .None
+    }
+
+    private let startFrameView = NSImageView()
+    private let endFrameView = NSImageView()
+
+    private lazy var playButton: NSButton = NSButton() ※ { b in
+        b.setButtonType(.MomentaryLightButton)
+        b.bezelStyle = .CircularBezelStyle
+        b.target = self
+    }
+    private func updatePlayButton() {
+        let playing = (player.rate != 0)
+        playButton.title = playing ? "■" : "▶"
+        playButton.action = playing ? "pause" : "play"
+
+        if !playing {
+            player.seekToTime(posterTime, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero)
+        }
+    }
+
+    var startTime: CMTime { didSet { updateLabels() } }
+    var posterTime: CMTime { didSet { updateLabels() } }
+    var endTime: CMTime { didSet { updateLabels() } }
+    private lazy var startLabel: NSTextField = NSTextField() ※ self.label
+    private lazy var posterLabel: NSTextField = NSTextField() ※ self.label
+    private lazy var endLabel: NSTextField = NSTextField() ※ self.label
+    private func label(tf: NSTextField) {
+        tf.bezeled = false
+        tf.editable = false
+        tf.drawsBackground = false
+        tf.textColor = NSColor.grayColor()
+        tf.font = NSFont.monospacedDigitSystemFontOfSize(12, weight: NSFontWeightRegular)
+    }
+    private func updateLabels() {
+        startLabel.stringValue = startTime.stringInmmssSS
+        posterLabel.stringValue = posterTime.stringInmmssSS
+        endLabel.stringValue = endTime.stringInmmssSS
+    }
+
+    init!(player: AVPlayer) {
+        let asset = player.currentItem?.asset
+        let item = asset.map {AVPlayerItem(asset: $0)}
+
+        posterTime = player.currentTime()
+        let duration = item?.duration ?? kCMTimeZero
+        let livePhotoDuration: NSTimeInterval = 3
+        let offset = CMTime(seconds: livePhotoDuration / 2, preferredTimescale: posterTime.timescale)
+        startTime = CMTimeMaximum(kCMTimeZero, CMTimeSubtract(posterTime, offset))
+        endTime = CMTimeMinimum(CMTimeAdd(posterTime, offset), duration)
+
+        self.player = item.map {AVPlayer(playerItem: $0)} ?? player
+        item?.forwardPlaybackEndTime = endTime
+
+        super.init(nibName: nil, bundle: nil)
+        guard let _ = item else { return nil }
+
+        self.player.volume = player.volume
+        self.player.actionAtItemEnd = .Pause
+        self.playerView.player = self.player
+
+        self.player.addObserver(self, forKeyPath: "rate", options: [], context: nil)
+        updatePlayButton()
+        play()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        player.removeObserver(self, forKeyPath: "rate")
+    }
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
+
+        let autolayout = view.northLayoutFormat(["p": 8], [
+            "player": playerView,
+            "play": playButton,
+            "startFrame": startFrameView,
+            "startLabel": startLabel,
+            "posterLabel": posterLabel,
+            "endFrame": endFrameView,
+            "endLabel": endLabel,
+            "spacerL": NSView(),
+            "spacerR": NSView(),
+            ])
+        autolayout("H:|-p-[player(>=300)]-p-|")
+        autolayout("H:|-p-[startFrame]-(>=p)-[endFrame(==startFrame)]-p-|")
+        autolayout("H:|-p-[startLabel][spacerL][posterLabel][spacerR(==spacerL)][endLabel]-p-|")
+        autolayout("H:|-p-[play]-p-|")
+        autolayout("V:|-p-[player(>=300)]")
+        autolayout("V:[player]-p-[play]-(>=0)-[posterLabel]-p-|")
+        autolayout("V:[player]-p-[startFrame(==128)][startLabel]-p-|")
+        autolayout("V:[player]-p-[endFrame(==startFrame)][endLabel]-p-|")
+
+        if let videoSize = player.currentItem?.naturalSize {
+            playerView.addConstraint(NSLayoutConstraint(item: playerView, attribute: .Height, relatedBy: .Equal,
+                toItem: playerView, attribute: .Width, multiplier: videoSize.height / videoSize.width, constant: 0))
+        }
+
+        if  let asset = player.currentItem?.asset,
+            let imageGenerator = AVAssetImageGenerator(asset: asset) as AVAssetImageGenerator?,
+            let startImage = imageGenerator.copyImage(at: startTime),
+            let endImage = imageGenerator.copyImage(at: endTime) {
+                startFrameView.image = startImage
+                endFrameView.image = endImage
+
+                startFrameView.addConstraint(NSLayoutConstraint(item: startFrameView, attribute: .Width, relatedBy: .Equal, toItem: startFrameView, attribute: .Height, multiplier: startImage.size.width / startImage.size.height, constant: 0))
+        }
+
+        updateLabels()
+    }
+
+    @objc private func play() {
+        player.seekToTime(startTime, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero)
+        player.play()
+    }
+
+    @objc private func pause() {
+        player.pause()
+    }
+
+    override func observeValueForKeyPath(keyPath: String?, ofObject object: AnyObject?, change: [String : AnyObject]?, context: UnsafeMutablePointer<Void>) {
+        switch (object, keyPath) {
+        case (is AVPlayer, _):
+            updatePlayButton()
+            break
+        default:
+            super.observeValueForKeyPath(keyPath, ofObject: object, change: change, context: context)
+        }
+    }
+}

--- a/LoveLiver-osx/LivePhotoSandboxViewController.swift
+++ b/LoveLiver-osx/LivePhotoSandboxViewController.swift
@@ -28,6 +28,20 @@ private func label() -> NSTextField {
 
 
 class LivePhotoSandboxViewController: NSViewController {
+    private lazy var exportButton: NSButton = NSButton() ※ { b in
+        b.bezelStyle = .RegularSquareBezelStyle
+        b.title = "Create Live Photo"
+        b.target = self
+        b.action = "export"
+    }
+    private lazy var closeButton: NSButton = NSButton() ※ { b in
+        b.bezelStyle = .RegularSquareBezelStyle
+        b.title = "Close"
+        b.target = self
+        b.action = "close"
+    }
+    var closeAction: (Void -> Void)?
+
     private let player: AVPlayer
     private let playerView: AVPlayerView = AVPlayerView() ※ { v in
         v.controlsStyle = .None
@@ -128,6 +142,8 @@ class LivePhotoSandboxViewController: NSViewController {
         view = NSView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
 
         let autolayout = view.northLayoutFormat(["p": 8], [
+            "export": exportButton,
+            "close": closeButton,
             "player": playerView,
             "overview": overview,
             "startFrame": startFrameView,
@@ -142,11 +158,13 @@ class LivePhotoSandboxViewController: NSViewController {
             "spacerRL": NSView(),
             "spacerRR": NSView(),
             ])
+        autolayout("H:|-p-[close]-(>=p)-[export]-p-|")
         autolayout("H:|-p-[player(>=300)]-p-|")
         autolayout("H:|-p-[startFrame]-(>=p)-[endFrame(==startFrame)]-p-|")
         autolayout("H:|-p-[startLabel][spacerLL][beforePosterLabel][spacerLR(==spacerLL)][posterLabel][spacerRL(==spacerLL)][afterPosterLabel][spacerRR(==spacerLL)][endLabel]-p-|")
         autolayout("H:|-p-[overview]-p-|")
-        autolayout("V:|-p-[player(>=300)]")
+        autolayout("V:|-p-[export]-p-[player(>=300)]")
+        autolayout("V:|-p-[close]-p-[player]")
         autolayout("V:[player][overview(==64)]")
         autolayout("V:[overview]-p-[startFrame(==128)][startLabel]-p-|")
         autolayout("V:[startFrame][beforePosterLabel]")
@@ -187,6 +205,14 @@ class LivePhotoSandboxViewController: NSViewController {
         if !dragging {
             updateImages()
         }
+    }
+
+    @objc private func export() {
+        NSLog("%@", "TODO: export live photo")
+    }
+
+    @objc private func close() {
+        closeAction?()
     }
 
     @objc private func play() {

--- a/LoveLiver-osx/MovieDocument.swift
+++ b/LoveLiver-osx/MovieDocument.swift
@@ -29,6 +29,7 @@ class MovieDocument: NSDocument, NSWindowDelegate {
 
     override func makeWindowControllers() {
         mainVC = MovieDocumentViewController(movieURL: fileURL!, playerItem: playerItem!, player: player!)
+        mainVC?.createLivePhotoAction = {[weak self] in self?.openLivePhotoSandbox()}
         mainWindow = NSWindow(contentViewController: mainVC!) ※ { w in
             w.delegate = self
         }
@@ -65,6 +66,20 @@ class MovieDocument: NSDocument, NSWindowDelegate {
         mainVC?.movieDidLoad(videoSize)
         overviewVC?.movieDidLoad(videoSize)
         repositionOverviewWindow()
+    }
+
+    private func openLivePhotoSandbox() {
+        guard let player = player else { return }
+        guard let overview = overviewVC?.overview else { return }
+
+        let livephotoSandboxVC = LivePhotoSandboxViewController(player: player, baseFilename: fileURL?.lastPathComponent ?? "unknown")
+        let popover = NSPopover()
+        livephotoSandboxVC.closeAction = {
+            popover.performClose(nil)
+        }
+        popover.behavior = .Semitransient
+        popover.contentViewController = livephotoSandboxVC
+        popover.showRelativeToRect(overview.currentTimeBar.frame, ofView: overview, preferredEdge: NSRectEdge.MinY)
     }
 
     func windowDidResize(notification: NSNotification) {

--- a/LoveLiver-osx/MovieDocument.swift
+++ b/LoveLiver-osx/MovieDocument.swift
@@ -7,17 +7,93 @@
 //
 
 import Cocoa
+import AVFoundation
+import Ikemen
 
 
-class MovieDocument: NSDocument {
+class MovieDocument: NSDocument, NSWindowDelegate {
+    var player: AVPlayer?
+    var playerItem: AVPlayerItem?
+    var mainWindow: NSWindow?
+    var mainVC: MovieDocumentViewController?
+    var overviewWindow: NSWindow?
+    var overviewVC: MovieOverviewViewController?
+
     override func readFromURL(url: NSURL, ofType typeName: String) throws {
         NSLog("%@", "opening \(url)")
+
+        playerItem = AVPlayerItem(URL: url)
+        guard let playerItem = playerItem else { throw NSError(domain: "MovieDocument", code: 0, userInfo: [:]) }
+        player = AVPlayer(playerItem: playerItem)
     }
 
     override func makeWindowControllers() {
-        let vc = MovieDocumentViewController(movieURL: fileURL!)
-        let window = NSWindow(contentViewController: vc)
-        let wc = NSWindowController(window: window)
-        addWindowController(wc)
+        mainVC = MovieDocumentViewController(movieURL: fileURL!, playerItem: playerItem!, player: player!)
+        mainWindow = NSWindow(contentViewController: mainVC!) ※ { w in
+            w.delegate = self
+        }
+        addWindowController(NSWindowController(window: mainWindow) ※ { wc in
+            wc.shouldCloseDocument = true
+            })
+        windowControllers.forEach { wc in
+            wc.showWindow(nil)
+        }
+        dispatch_async(dispatch_get_main_queue()) {
+            self.waitForMovieLoaded()
+        }
+    }
+
+    private func waitForMovieLoaded() {
+        guard let videoSize = playerItem?.naturalSize else {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(1 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) {
+                self.waitForMovieLoaded()
+            }
+            return
+        }
+        movieDidLoad(videoSize)
+    }
+
+    private func movieDidLoad(videoSize: CGSize) {
+        overviewVC = MovieOverviewViewController(player: player!)
+        overviewWindow = NSWindow(contentViewController: overviewVC!) ※ { w in
+            w.delegate = self
+            w.styleMask = NSResizableWindowMask
+        }
+        addWindowController(NSWindowController(window: overviewWindow))
+        mainWindow!.addChildWindow(overviewWindow!, ordered: .Above)
+
+        mainVC?.movieDidLoad(videoSize)
+        overviewVC?.movieDidLoad(videoSize)
+        repositionOverviewWindow()
+    }
+
+    func windowDidResize(notification: NSNotification) {
+        if notification.object === mainWindow {
+            repositionOverviewWindow()
+        } else if notification.object === overviewWindow {
+            repositionMainWindow()
+        }
+    }
+
+    private var metrics: [String: CGFloat] = [
+        "p": 20,
+    ]
+
+    private func repositionMainWindow() {
+        guard let mainWindow = mainWindow, let overviewWindow = overviewWindow else { return }
+
+        mainWindow.removeChildWindow(overviewWindow)
+        mainWindow.setFrameOrigin(NSPoint(
+            x: overviewWindow.frame.origin.x - (mainWindow.frame.width - overviewWindow.frame.width) / 2,
+            y: overviewWindow.frame.origin.y + overviewWindow.frame.height + metrics["p"]!))
+        mainWindow.addChildWindow(overviewWindow, ordered: .Above)
+    }
+
+    private func repositionOverviewWindow() {
+        guard let mainWindow = mainWindow, let overviewWindow = overviewWindow else { return }
+
+        overviewWindow.setFrameTopLeftPoint(NSPoint(
+            x: mainWindow.frame.origin.x + (mainWindow.frame.width - overviewWindow.frame.width) / 2,
+            y: mainWindow.frame.origin.y - metrics["p"]!))
     }
 }

--- a/LoveLiver-osx/MovieDocument.swift
+++ b/LoveLiver-osx/MovieDocument.swift
@@ -54,7 +54,7 @@ class MovieDocument: NSDocument, NSWindowDelegate {
     }
 
     private func movieDidLoad(videoSize: CGSize) {
-        overviewVC = MovieOverviewViewController(player: player!)
+        overviewVC = MovieOverviewViewController(player: player!, playerItem: playerItem!)
         overviewWindow = NSWindow(contentViewController: overviewVC!) ※ { w in
             w.delegate = self
             w.styleMask = NSResizableWindowMask

--- a/LoveLiver-osx/MovieDocumentViewController.swift
+++ b/LoveLiver-osx/MovieDocumentViewController.swift
@@ -17,6 +17,7 @@ class MovieDocumentViewController: NSViewController {
     private let movieURL: NSURL
     private let player: AVPlayer
     private let playerItem: AVPlayerItem
+    var createLivePhotoAction: (Void -> Void)?
 
     private let playerView: AVPlayerView = AVPlayerView() ※ { v in
         v.controlsStyle = .Floating
@@ -62,14 +63,6 @@ class MovieDocumentViewController: NSViewController {
 
     @objc private func createLivePhotoSandbox() {
         player.pause()
-
-        let livephotoSandboxVC = LivePhotoSandboxViewController(player: player, baseFilename: movieURL.lastPathComponent ?? "unknown")
-        let popover = NSPopover()
-        livephotoSandboxVC.closeAction = {
-            popover.performClose(nil)
-        }
-        popover.behavior = .Semitransient
-        popover.contentViewController = livephotoSandboxVC
-        popover.showRelativeToRect(posterFrameButton.bounds, ofView: posterFrameButton, preferredEdge: NSRectEdge.MinY)
+        createLivePhotoAction?()
     }
 }

--- a/LoveLiver-osx/MovieDocumentViewController.swift
+++ b/LoveLiver-osx/MovieDocumentViewController.swift
@@ -113,6 +113,11 @@ class MovieDocumentViewController: NSViewController {
         posterFrameView.image = imageGenerator.copyImage(at: player.currentTime())
         posterFrameTime = player.currentTime()
         updateViews()
+
+        let popover = NSPopover()
+        popover.behavior = .Transient
+        popover.contentViewController = LivePhotoSandboxViewController(player: player)
+        popover.showRelativeToRect(posterFrameButton.bounds, ofView: posterFrameButton, preferredEdge: NSRectEdge.MinY)
     }
 
     @objc private func createLivePhoto(sender: AnyObject?) {

--- a/LoveLiver-osx/MovieDocumentViewController.swift
+++ b/LoveLiver-osx/MovieDocumentViewController.swift
@@ -114,9 +114,13 @@ class MovieDocumentViewController: NSViewController {
         posterFrameTime = player.currentTime()
         updateViews()
 
+        let livephotoSandboxVC = LivePhotoSandboxViewController(player: player)
         let popover = NSPopover()
-        popover.behavior = .Transient
-        popover.contentViewController = LivePhotoSandboxViewController(player: player)
+        livephotoSandboxVC.closeAction = {
+            popover.performClose(nil)
+        }
+        popover.behavior = .Semitransient
+        popover.contentViewController = livephotoSandboxVC
         popover.showRelativeToRect(posterFrameButton.bounds, ofView: posterFrameButton, preferredEdge: NSRectEdge.MinY)
     }
 

--- a/LoveLiver-osx/MovieDocumentViewController.swift
+++ b/LoveLiver-osx/MovieDocumentViewController.swift
@@ -17,41 +17,17 @@ class MovieDocumentViewController: NSViewController {
     private let movieURL: NSURL
     private let player: AVPlayer
     private let playerItem: AVPlayerItem
-    private let imageGenerator: AVAssetImageGenerator
-    private var posterFrameTime: CMTime?
 
     private let playerView: AVPlayerView = AVPlayerView() ※ { v in
         v.controlsStyle = .Floating
         v.showsFrameSteppingButtons = true
     }
-    private let posterFrameView = NSImageView() ※ { v in
-        v.imageScaling = .ScaleProportionallyUpOrDown
-        v.wantsLayer = true
-        v.layer?.backgroundColor = NSColor.blackColor().CGColor
-        v.setContentCompressionResistancePriority(NSLayoutPriorityFittingSizeCompression, forOrientation: .Horizontal)
-        v.setContentCompressionResistancePriority(NSLayoutPriorityFittingSizeCompression, forOrientation: .Vertical)
-    }
     private lazy var posterFrameButton: NSButton = NSButton() ※ { b in
-        b.title = "Poster Frame ->>"
+        b.title = "Live Photo With This Frame"
         b.setButtonType(.MomentaryLightButton)
         b.bezelStyle = .RoundedBezelStyle
         b.target = self
-        b.action = "capturePosterFrame:"
-    }
-
-    private lazy var positionsLabel: NSTextField = NSTextField() ※ { tf in
-        tf.bezeled = false
-        tf.editable = false
-        tf.drawsBackground = false
-        tf.textColor = NSColor.grayColor()
-    }
-
-    private lazy var createLivePhotoButton: NSButton = NSButton() ※ { b in
-        b.title = "Create Live Photo"
-        b.setButtonType(.MomentaryLightButton)
-        b.bezelStyle = .RoundedBezelStyle
-        b.target = self
-        b.action = "createLivePhoto:"
+        b.action = "createLivePhotoSandbox"
     }
 
     init!(movieURL: NSURL, playerItem: AVPlayerItem, player: AVPlayer) {
@@ -59,10 +35,6 @@ class MovieDocumentViewController: NSViewController {
         self.playerItem = playerItem
         self.player = player
         playerView.player = player
-        imageGenerator = AVAssetImageGenerator(asset: playerItem.asset) ※ {
-            $0.requestedTimeToleranceBefore = kCMTimeZero
-            $0.requestedTimeToleranceAfter = kCMTimeZero
-        }
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -73,20 +45,13 @@ class MovieDocumentViewController: NSViewController {
     override func loadView() {
         view = NSView(frame: NSRect(x: 0, y: 0, width: 500, height: 500))
 
-        let autolayout = view.northLayoutFormat(["p": 20], [
+        let autolayout = view.northLayoutFormat(["p": 16], [
             "player": playerView,
             "posterButton": posterFrameButton,
-            "posterView": posterFrameView,
-            "createLivePhoto": createLivePhotoButton,
-            "positionsLabel": positionsLabel,
             ])
-        autolayout("H:|-p-[player]-p-[posterView(==player)]-p-|")
-        autolayout("H:|-p-[posterButton(==player)]-p-[createLivePhoto(<=player)]-p-|")
-        autolayout("H:[positionsLabel(==createLivePhoto)]-p-|")
-        autolayout("V:|-p-[player]-p-[posterButton]-p-|")
-        autolayout("V:|-p-[posterView][positionsLabel(==p)][createLivePhoto]-p-|")
-
-        updateViews()
+        autolayout("H:|[player]|")
+        autolayout("H:|-p-[posterButton]-p-|")
+        autolayout("V:|[player]-p-[posterButton]-p-|")
     }
 
     func movieDidLoad(videoSize: CGSize) {
@@ -95,21 +60,7 @@ class MovieDocumentViewController: NSViewController {
             toItem: self.playerView, attribute: .Height, multiplier: videoSize.width / videoSize.height, constant: 0))
     }
 
-    private func updateViews() {
-        createLivePhotoButton.enabled = (posterFrameView.image != nil)
-        positionsLabel.stringValue = positionsLabelText
-    }
-
-    private var positionsLabelText: String {
-        guard let time = posterFrameTime else { return "" }
-        return "Poster Frame: \(time.stringInmmssSS)"
-    }
-
-    @objc private func capturePosterFrame(sender: AnyObject?) {
-        posterFrameView.image = imageGenerator.copyImage(at: player.currentTime())
-        posterFrameTime = player.currentTime()
-        updateViews()
-
+    @objc private func createLivePhotoSandbox() {
         let livephotoSandboxVC = LivePhotoSandboxViewController(player: player, baseFilename: movieURL.lastPathComponent ?? "unknown")
         let popover = NSPopover()
         livephotoSandboxVC.closeAction = {

--- a/LoveLiver-osx/MovieDocumentViewController.swift
+++ b/LoveLiver-osx/MovieDocumentViewController.swift
@@ -61,6 +61,8 @@ class MovieDocumentViewController: NSViewController {
     }
 
     @objc private func createLivePhotoSandbox() {
+        player.pause()
+
         let livephotoSandboxVC = LivePhotoSandboxViewController(player: player, baseFilename: movieURL.lastPathComponent ?? "unknown")
         let popover = NSPopover()
         livephotoSandboxVC.closeAction = {

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -138,10 +138,11 @@ class MovieOverviewControl: NSView {
         NSColor.blackColor().setFill()
         NSRectFillUsingOperation(dirtyRect, .CompositeCopy)
 
-        let cellWidth = bounds.width / CGFloat(numberOfPages)
-        for (i, t) in thumbnails.enumerate() {
-            let pageRect = NSRect(x: CGFloat(i) * cellWidth, y: 0, width: cellWidth, height: bounds.height)
+        var x: CGFloat = 0
+        for t in thumbnails {
+            let pageRect = NSRect(x: x, y: 0, width: bounds.height / t.size.height * t.size.width, height: bounds.height)
             t.drawInRect(pageRect)
+            x += pageRect.width
         }
     }
 

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -40,16 +40,27 @@ class MovieOverviewControl: NSView {
         didSet { setNeedsDisplayInRect(bounds) }
     }
     var thumbnails = [NSImage]()
+    var imageGeneratorTolerance = CMTime(seconds: 300, preferredTimescale: 600)
 
-    var startTime: CMTime? { didSet { reload() } }
-    var endTime: CMTime? { didSet { reload() } }
-    var scopedDuration: CMTime {
-        guard let item = player.currentItem else { return kCMTimeZero }
-        return CMTimeSubtract(endTime ?? item.duration, startTime ?? kCMTimeZero)
+    // overview control supports timmed playback and scope edit
+    var trimRange: CMTimeRange { didSet { reload() } } // show overview only within trimRange
+    var scopeRange: CMTimeRange? { // if non-nil, shows scope control
+        didSet { updateScope() }
+    }
+    private lazy var scopeMaskLeftView: NSView = NSView(frame: NSZeroRect) ※ { v in
+        v.wantsLayer = true
+        v.layer?.backgroundColor = NSColor(white: 0, alpha: 0.75).CGColor
+        v.hidden = true
+    }
+    private lazy var scopeMaskRightView: NSView = NSView(frame: NSZeroRect) ※ { v in
+        v.wantsLayer = true
+        v.layer?.backgroundColor = NSColor(white: 0, alpha: 0.75).CGColor
+        v.hidden = true
     }
 
-    init(player: AVPlayer) {
+    init(player: AVPlayer, playerItem: AVPlayerItem) {
         self.player = player
+        self.trimRange = CMTimeRange(start: kCMTimeZero, duration: playerItem.duration)
         
         super.init(frame: NSZeroRect)
 
@@ -61,6 +72,17 @@ class MovieOverviewControl: NSView {
 
         setContentCompressionResistancePriority(NSLayoutPriorityDefaultHigh, forOrientation: .Vertical)
         setContentHuggingPriority(NSLayoutPriorityDefaultHigh, forOrientation: .Vertical)
+
+        // subviews ordering
+        addSubview(scopeMaskLeftView)
+        addSubview(scopeMaskRightView)
+        sortSubviewsUsingFunction({ (v1, v2, context) -> NSComparisonResult in
+            let s = Unmanaged<MovieOverviewControl>.fromOpaque(COpaquePointer(context)).takeUnretainedValue()
+            switch (v1, v2) {
+            case (s.currentTimeLabel, _): return .OrderedDescending
+            default: return .OrderedSame
+            }
+            }, context: UnsafeMutablePointer<Void>(Unmanaged.passUnretained(self).toOpaque()))
 
         observePlayer()
         updateCurrentTime()
@@ -89,13 +111,15 @@ class MovieOverviewControl: NSView {
         let pageSize = NSSize(width: bounds.height / videoSize.height * videoSize.width, height: bounds.height)
         numberOfPages = UInt(ceil(bounds.width / pageSize.width))
         let times: [CMTime] = (0..<numberOfPages).map { i in
-            CMTimeAdd(startTime ?? kCMTimeZero, CMTime(value: scopedDuration.value * Int64(i) / Int64(numberOfPages), timescale: scopedDuration.timescale))
+            CMTimeAdd(trimRange.start, CMTime(value: trimRange.duration.value * Int64(i) / Int64(numberOfPages), timescale: trimRange.duration.timescale))
         }
 
         // generate thumbnails for each page in background
         let generator = AVAssetImageGenerator(asset: item.asset) ※ {
             let scale = window?.backingScaleFactor ?? 1
             $0.maximumSize = CGSize(width: pageSize.width * scale, height: pageSize.height * scale)
+            $0.requestedTimeToleranceBefore = imageGeneratorTolerance
+            $0.requestedTimeToleranceAfter = imageGeneratorTolerance
         }
         imageGenerator = generator
         generator.generateCGImagesAsynchronouslyForTimes(times.map {NSValue(CMTime: $0)}) { (requestedTime, cgImage, actualTime, result, error) -> Void in
@@ -133,14 +157,36 @@ class MovieOverviewControl: NSView {
 
     private func updateCurrentTime() {
         if let time = currentTime {
-            let p = CGFloat(CMTimeSubtract(time, startTime ?? kCMTimeZero).convertScale(scopedDuration.timescale, method: CMTimeRoundingMethod.Default).value)
-                / CGFloat(scopedDuration.value)
+            let p = CGFloat(CMTimeSubtract(time, trimRange.start).convertScale(trimRange.duration.timescale, method: CMTimeRoundingMethod.Default).value)
+                / CGFloat(trimRange.duration.value)
             currentTimeBar.hidden = false
             currentTimeBar.frame = NSRect(x: p * bounds.width, y: 0, width: 1, height: bounds.height)
             currentTimeLabel.stringValue = time.stringInmmssSS
         } else {
             currentTimeBar.hidden = true
             currentTimeLabel.stringValue = "--:--.--"
+        }
+    }
+
+    private func updateScope() {
+        if let s = scopeRange {
+            let startPercent = CGFloat(CMTimeSubtract(s.start, trimRange.start).convertScale(trimRange.duration.timescale, method: CMTimeRoundingMethod.Default).value)
+                / CGFloat(trimRange.duration.value)
+            let endPercent = CGFloat(CMTimeSubtract(s.end, trimRange.start).convertScale(trimRange.duration.timescale, method: CMTimeRoundingMethod.Default).value)
+                / CGFloat(trimRange.duration.value)
+
+            scopeMaskLeftView.hidden = false
+            scopeMaskRightView.hidden = false
+
+            scopeMaskLeftView.frame = NSRect(x: 0, y: 0, width: startPercent * bounds.width, height: bounds.height)
+            scopeMaskRightView.frame = NSRect(x: endPercent * bounds.width, y: 0, width: bounds.width - endPercent * bounds.width, height: bounds.height)
+
+            player.currentItem?.forwardPlaybackEndTime = s.end
+        } else {
+            scopeMaskLeftView.hidden = true
+            scopeMaskRightView.hidden = true
+
+            player.currentItem?.forwardPlaybackEndTime = trimRange.end
         }
     }
 
@@ -166,7 +212,7 @@ class MovieOverviewControl: NSView {
 
     private func seekToMousePosition(theEvent: NSEvent) {
         let p = convertPoint(theEvent.locationInWindow, fromView: nil)
-        let time = CMTimeAdd(CMTime(value: Int64(CGFloat(scopedDuration.value) * p.x / bounds.width), timescale: scopedDuration.timescale), startTime ?? kCMTimeZero)
+        let time = CMTimeAdd(CMTime(value: Int64(CGFloat(trimRange.duration.value) * p.x / bounds.width), timescale: trimRange.duration.timescale), trimRange.start)
         player.seekToTime(time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero)
     }
 }

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -79,7 +79,8 @@ class MovieOverviewControl: NSView {
 
         // generate thumbnails for each page in background
         let generator = AVAssetImageGenerator(asset: item.asset) ※ {
-            $0.maximumSize = pageSize
+            let scale = window?.backingScaleFactor ?? 1
+            $0.maximumSize = CGSize(width: pageSize.width * scale, height: pageSize.height * scale)
         }
         imageGenerator = generator
         generator.generateCGImagesAsynchronouslyForTimes(times.map {NSValue(CMTime: $0)}) { (requestedTime, cgImage, actualTime, result, error) -> Void in

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -21,7 +21,7 @@ class MovieOverviewControl: NSView {
     var currentTime: CMTime? {
         didSet { updateCurrentTime() }
     }
-    private lazy var currentTimeBar: NSView = NSView(frame: NSZeroRect) ※ { v in
+    private(set) lazy var currentTimeBar: NSView = NSView(frame: NSZeroRect) ※ { v in
         v.wantsLayer = true
         v.layer?.backgroundColor = NSColor.redColor().CGColor
         self.addSubview(v)

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import AVFoundation
 import Ikemen
+import NorthLayout
 
 
 private let overviewHeight: CGFloat = 64
@@ -27,10 +28,12 @@ class MovieOverviewControl: NSView {
     }
     var playerTimeObserver: AnyObject?
     var currentTimePercent: CGFloat? {
-        didSet {
-            // FIXME: redraw only dirty rect
-            setNeedsDisplayInRect(bounds)
-        }
+        didSet { updateCurrentTimeBar() }
+    }
+    private lazy var currentTimeBar: NSView = NSView(frame: NSZeroRect) ※ { v in
+        v.wantsLayer = true
+        v.layer?.backgroundColor = NSColor.redColor().CGColor
+        self.addSubview(v)
     }
     var imageGenerator: AVAssetImageGenerator?
     var numberOfPages: UInt = 0 {
@@ -118,6 +121,19 @@ class MovieOverviewControl: NSView {
         reload()
     }
 
+    override var frame: NSRect {
+        didSet { updateCurrentTimeBar() }
+    }
+
+    private func updateCurrentTimeBar() {
+        if let p = currentTimePercent {
+            currentTimeBar.hidden = false
+            currentTimeBar.frame = NSRect(x: p * bounds.width, y: 0, width: 1, height: bounds.height)
+        } else {
+            currentTimeBar.hidden = true
+        }
+    }
+
     override func drawRect(dirtyRect: NSRect) {
         NSColor.blackColor().setFill()
         NSRectFillUsingOperation(dirtyRect, .CompositeCopy)
@@ -126,11 +142,6 @@ class MovieOverviewControl: NSView {
         for (i, t) in thumbnails.enumerate() {
             let pageRect = NSRect(x: CGFloat(i) * cellWidth, y: 0, width: cellWidth, height: bounds.height)
             t.drawInRect(pageRect)
-        }
-
-        if let currentTimePercent = currentTimePercent {
-            NSColor.redColor().setFill()
-            NSRectFillUsingOperation(NSRect(x: currentTimePercent * bounds.width, y: 0, width: 1, height: bounds.height), .CompositeCopy)
         }
     }
 

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -95,4 +95,13 @@ class MovieOverviewControl: NSView {
             t.drawInRect(pageRect)
         }
     }
+
+    override func mouseDown(theEvent: NSEvent) {
+        guard let item = player?.currentItem else { return }
+        let duration = item.duration
+
+        let p = convertPoint(theEvent.locationInWindow, fromView: nil)
+        let time = CMTime(value: Int64(CGFloat(duration.value) * p.x / bounds.width), timescale: duration.timescale)
+        player?.seekToTime(time)
+    }
 }

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -147,11 +147,19 @@ class MovieOverviewControl: NSView {
     }
 
     override func mouseDown(theEvent: NSEvent) {
+        seekToMousePosition(theEvent)
+    }
+
+    override func mouseDragged(theEvent: NSEvent) {
+        seekToMousePosition(theEvent)
+    }
+
+    private func seekToMousePosition(theEvent: NSEvent) {
         guard let item = player?.currentItem else { return }
         let duration = item.duration
 
         let p = convertPoint(theEvent.locationInWindow, fromView: nil)
         let time = CMTime(value: Int64(CGFloat(duration.value) * p.x / bounds.width), timescale: duration.timescale)
-        player?.seekToTime(time)
+        player?.seekToTime(time, toleranceBefore: kCMTimeZero, toleranceAfter: kCMTimeZero)
     }
 }

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -1,0 +1,88 @@
+//
+//  MovieOverviewControl.swift
+//  LoveLiver
+//
+//  Created by BAN Jun on 2016/03/15.
+//  Copyright © 2016年 mzp. All rights reserved.
+//
+
+import Cocoa
+import AVFoundation
+
+
+private let overviewHeight: CGFloat = 64
+
+
+class MovieOverviewControl: NSView {
+    var player: AVPlayer? {
+        didSet { reload() }
+    }
+    var numberOfPages: UInt = 0 {
+        didSet { setNeedsDisplayInRect(bounds) }
+    }
+    var thumbnails = [NSImage]()
+
+    init(player: AVPlayer) {
+        self.player = player
+        
+        super.init(frame: NSZeroRect)
+
+        setContentCompressionResistancePriority(NSLayoutPriorityDefaultHigh, forOrientation: .Vertical)
+        setContentHuggingPriority(NSLayoutPriorityDefaultHigh, forOrientation: .Vertical)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        return nil
+    }
+
+    override var intrinsicContentSize: NSSize {
+        return CGSize(width: NSViewNoIntrinsicMetric, height: overviewHeight)
+    }
+
+    func reload() {
+        thumbnails.removeAll()
+        guard let item = player?.currentItem,
+            let track = item.asset.tracksWithMediaType(AVMediaTypeVideo).first else {
+                numberOfPages = 0
+                return
+        }
+
+        let thumbSize = NSSize(width: bounds.height / track.naturalSize.height * track.naturalSize.width, height: bounds.height)
+        numberOfPages = UInt(ceil(bounds.width / thumbSize.width))
+        let duration = item.duration
+
+        dispatch_async(dispatch_get_global_queue(0, 0)) {
+            let generator = AVAssetImageGenerator(asset: item.asset)
+            for i in 0..<self.numberOfPages {
+                let thumb = NSImage(size: thumbSize)
+                thumb.lockFocus()
+                let frameImage = generator.copyImage(at: CMTime(value: duration.value * Int64(i) / Int64(self.numberOfPages), timescale: duration.timescale))
+                frameImage?.drawInRect(NSRect(origin: CGPointZero, size: NSSizeToCGSize(thumbSize)))
+                thumb.unlockFocus()
+                
+                dispatch_async(dispatch_get_main_queue()) {
+                    self.thumbnails.append(thumb)
+                    self.setNeedsDisplayInRect(self.bounds)
+                }
+            }
+        }
+    }
+
+    override func viewDidEndLiveResize() {
+        super.viewDidEndLiveResize()
+
+        reload()
+    }
+
+    override func drawRect(dirtyRect: NSRect) {
+        NSColor.blackColor().setFill()
+        NSRectFillUsingOperation(dirtyRect, .CompositeCopy)
+
+        let cellWidth = bounds.width / CGFloat(numberOfPages)
+        for (i, t) in thumbnails.enumerate() {
+            let pageRect = NSRect(x: CGFloat(i) * cellWidth, y: 0, width: cellWidth, height: bounds.height)
+            t.drawInRect(pageRect)
+        }
+    }
+}

--- a/LoveLiver-osx/MovieOverviewControl.swift
+++ b/LoveLiver-osx/MovieOverviewControl.swift
@@ -8,6 +8,7 @@
 
 import Cocoa
 import AVFoundation
+import Ikemen
 
 
 private let overviewHeight: CGFloat = 64
@@ -77,15 +78,14 @@ class MovieOverviewControl: NSView {
         }
 
         // generate thumbnails for each page in background
-        let generator = AVAssetImageGenerator(asset: item.asset)
+        let generator = AVAssetImageGenerator(asset: item.asset) ※ {
+            $0.maximumSize = pageSize
+        }
         imageGenerator = generator
         generator.generateCGImagesAsynchronouslyForTimes(times.map {NSValue(CMTime: $0)}) { (requestedTime, cgImage, actualTime, result, error) -> Void in
-            guard result == .Succeeded else { return }
+            guard let cgImage = cgImage where result == .Succeeded else { return }
 
-            let thumb = NSImage(size: pageSize)
-            thumb.lockFocus()
-            CGContextDrawImage(NSGraphicsContext.currentContext()!.CGContext, CGRect(origin: CGPointZero, size: NSSizeToCGSize(pageSize)), cgImage)
-            thumb.unlockFocus()
+            let thumb = NSImage(CGImage: cgImage, size: NSZeroSize)
 
             dispatch_async(dispatch_get_main_queue()) {
                 guard self.imageGenerator === generator else { return } // avoid appending result from outdated requests

--- a/LoveLiver-osx/MovieOverviewViewController.swift
+++ b/LoveLiver-osx/MovieOverviewViewController.swift
@@ -1,0 +1,39 @@
+//
+//  MovieOverviewViewController.swift
+//  LoveLiver
+//
+//  Created by BAN Jun on 2016/03/20.
+//  Copyright © 2016年 mzp. All rights reserved.
+//
+
+import Cocoa
+import AVFoundation
+import NorthLayout
+
+
+class MovieOverviewViewController: NSViewController {
+    private let overview: MovieOverviewControl
+    
+    init(player: AVPlayer) {
+        self.overview = MovieOverviewControl(player: player)
+        super.init(nibName: nil, bundle: nil)!
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = NSView(frame: NSRect(x: 0, y: 0, width: 500, height: 64))
+
+        let autolayout = view.northLayoutFormat([:], [
+            "overview": overview,
+            ])
+        autolayout("H:|-2-[overview(>=64@999)]-2-|")
+        autolayout("V:|[overview]|")
+    }
+
+    func movieDidLoad(videoSize: CGSize) {
+        overview.reload()
+    }
+}

--- a/LoveLiver-osx/MovieOverviewViewController.swift
+++ b/LoveLiver-osx/MovieOverviewViewController.swift
@@ -14,8 +14,8 @@ import NorthLayout
 class MovieOverviewViewController: NSViewController {
     private let overview: MovieOverviewControl
     
-    init(player: AVPlayer) {
-        self.overview = MovieOverviewControl(player: player)
+    init(player: AVPlayer, playerItem: AVPlayerItem) {
+        self.overview = MovieOverviewControl(player: player, playerItem: playerItem)
         super.init(nibName: nil, bundle: nil)!
     }
 

--- a/LoveLiver-osx/MovieOverviewViewController.swift
+++ b/LoveLiver-osx/MovieOverviewViewController.swift
@@ -12,7 +12,7 @@ import NorthLayout
 
 
 class MovieOverviewViewController: NSViewController {
-    private let overview: MovieOverviewControl
+    let overview: MovieOverviewControl
     
     init(player: AVPlayer, playerItem: AVPlayerItem) {
         self.overview = MovieOverviewControl(player: player, playerItem: playerItem)

--- a/LoveLiver.xcodeproj/project.pbxproj
+++ b/LoveLiver.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		133DFE3B1BC8C69900902407 /* JPEG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133DFE3A1BC8C69900902407 /* JPEG.swift */; };
 		133DFE3D1BC8C6EF00902407 /* QuickTimeMov.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133DFE3C1BC8C6EF00902407 /* QuickTimeMov.swift */; };
 		C2C41F0CC51A39D97981D73D /* Pods_LoveLiver_osx.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B34746BF27B18F34F5E26C5 /* Pods_LoveLiver_osx.framework */; };
+		EA27F5EF1C98426A00C23F40 /* MovieOverviewControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA27F5EE1C98426A00C23F40 /* MovieOverviewControl.swift */; };
 		EA379AB91C68DE6D00106AEF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA379AB81C68DE6D00106AEF /* AppDelegate.swift */; };
 		EA379ABB1C68DE6D00106AEF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EA379ABA1C68DE6D00106AEF /* Assets.xcassets */; };
 		EA379ABE1C68DE6D00106AEF /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = EA379ABC1C68DE6D00106AEF /* MainMenu.xib */; };
@@ -47,6 +48,7 @@
 		3B34746BF27B18F34F5E26C5 /* Pods_LoveLiver_osx.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LoveLiver_osx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F0CA317E59A557EE5DD45B6 /* Pods-LoveLiver-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LoveLiver-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-LoveLiver-osx/Pods-LoveLiver-osx.release.xcconfig"; sourceTree = "<group>"; };
 		DCD5B633553004CEA3DAF5F6 /* Pods-LoveLiver-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LoveLiver-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-LoveLiver-osx/Pods-LoveLiver-osx.debug.xcconfig"; sourceTree = "<group>"; };
+		EA27F5EE1C98426A00C23F40 /* MovieOverviewControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieOverviewControl.swift; sourceTree = "<group>"; };
 		EA379AB61C68DE6D00106AEF /* LoveLiver.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LoveLiver.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA379AB81C68DE6D00106AEF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		EA379ABA1C68DE6D00106AEF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -140,6 +142,7 @@
 				EA379AB81C68DE6D00106AEF /* AppDelegate.swift */,
 				EA379AD81C6A283500106AEF /* MovieDocument.swift */,
 				EA379ADC1C6A2E8800106AEF /* MovieDocumentViewController.swift */,
+				EA27F5EE1C98426A00C23F40 /* MovieOverviewControl.swift */,
 				EA379ABA1C68DE6D00106AEF /* Assets.xcassets */,
 				EA379ABC1C68DE6D00106AEF /* MainMenu.xib */,
 				EA379ABF1C68DE6D00106AEF /* Info.plist */,
@@ -305,6 +308,7 @@
 				EA379AB91C68DE6D00106AEF /* AppDelegate.swift in Sources */,
 				EA379ADF1C6A33A700106AEF /* QuickTimeMov.swift in Sources */,
 				EA379ADA1C6A283500106AEF /* MovieDocument.swift in Sources */,
+				EA27F5EF1C98426A00C23F40 /* MovieOverviewControl.swift in Sources */,
 				EA379ADD1C6A2E8800106AEF /* MovieDocumentViewController.swift in Sources */,
 				EA379ADE1C6A33A500106AEF /* JPEG.swift in Sources */,
 			);

--- a/LoveLiver.xcodeproj/project.pbxproj
+++ b/LoveLiver.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		EA379ADD1C6A2E8800106AEF /* MovieDocumentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA379ADC1C6A2E8800106AEF /* MovieDocumentViewController.swift */; };
 		EA379ADE1C6A33A500106AEF /* JPEG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133DFE3A1BC8C69900902407 /* JPEG.swift */; };
 		EA379ADF1C6A33A700106AEF /* QuickTimeMov.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133DFE3C1BC8C6EF00902407 /* QuickTimeMov.swift */; };
+		EA6D28871C9EF0FD00F06E79 /* AVKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6D28861C9EF0FD00F06E79 /* AVKitExtension.swift */; };
+		EA88135F1C9ED065000CE151 /* MovieOverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA88135E1C9ED065000CE151 /* MovieOverviewViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -56,6 +58,8 @@
 		EA379ABF1C68DE6D00106AEF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EA379AD81C6A283500106AEF /* MovieDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieDocument.swift; sourceTree = "<group>"; };
 		EA379ADC1C6A2E8800106AEF /* MovieDocumentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieDocumentViewController.swift; sourceTree = "<group>"; };
+		EA6D28861C9EF0FD00F06E79 /* AVKitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVKitExtension.swift; sourceTree = "<group>"; };
+		EA88135E1C9ED065000CE151 /* MovieOverviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieOverviewViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,7 +146,9 @@
 				EA379AB81C68DE6D00106AEF /* AppDelegate.swift */,
 				EA379AD81C6A283500106AEF /* MovieDocument.swift */,
 				EA379ADC1C6A2E8800106AEF /* MovieDocumentViewController.swift */,
+				EA88135E1C9ED065000CE151 /* MovieOverviewViewController.swift */,
 				EA27F5EE1C98426A00C23F40 /* MovieOverviewControl.swift */,
+				EA6D28861C9EF0FD00F06E79 /* AVKitExtension.swift */,
 				EA379ABA1C68DE6D00106AEF /* Assets.xcassets */,
 				EA379ABC1C68DE6D00106AEF /* MainMenu.xib */,
 				EA379ABF1C68DE6D00106AEF /* Info.plist */,
@@ -308,8 +314,10 @@
 				EA379AB91C68DE6D00106AEF /* AppDelegate.swift in Sources */,
 				EA379ADF1C6A33A700106AEF /* QuickTimeMov.swift in Sources */,
 				EA379ADA1C6A283500106AEF /* MovieDocument.swift in Sources */,
+				EA6D28871C9EF0FD00F06E79 /* AVKitExtension.swift in Sources */,
 				EA27F5EF1C98426A00C23F40 /* MovieOverviewControl.swift in Sources */,
 				EA379ADD1C6A2E8800106AEF /* MovieDocumentViewController.swift in Sources */,
+				EA88135F1C9ED065000CE151 /* MovieOverviewViewController.swift in Sources */,
 				EA379ADE1C6A33A500106AEF /* JPEG.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LoveLiver.xcodeproj/project.pbxproj
+++ b/LoveLiver.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		EA379ADE1C6A33A500106AEF /* JPEG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133DFE3A1BC8C69900902407 /* JPEG.swift */; };
 		EA379ADF1C6A33A700106AEF /* QuickTimeMov.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133DFE3C1BC8C6EF00902407 /* QuickTimeMov.swift */; };
 		EA6D28871C9EF0FD00F06E79 /* AVKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6D28861C9EF0FD00F06E79 /* AVKitExtension.swift */; };
+		EA6D28891C9EF49200F06E79 /* LivePhotoSandboxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6D28881C9EF49200F06E79 /* LivePhotoSandboxViewController.swift */; };
 		EA88135F1C9ED065000CE151 /* MovieOverviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA88135E1C9ED065000CE151 /* MovieOverviewViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -59,6 +60,7 @@
 		EA379AD81C6A283500106AEF /* MovieDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieDocument.swift; sourceTree = "<group>"; };
 		EA379ADC1C6A2E8800106AEF /* MovieDocumentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieDocumentViewController.swift; sourceTree = "<group>"; };
 		EA6D28861C9EF0FD00F06E79 /* AVKitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AVKitExtension.swift; sourceTree = "<group>"; };
+		EA6D28881C9EF49200F06E79 /* LivePhotoSandboxViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LivePhotoSandboxViewController.swift; sourceTree = "<group>"; };
 		EA88135E1C9ED065000CE151 /* MovieOverviewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MovieOverviewViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -147,6 +149,7 @@
 				EA379AD81C6A283500106AEF /* MovieDocument.swift */,
 				EA379ADC1C6A2E8800106AEF /* MovieDocumentViewController.swift */,
 				EA88135E1C9ED065000CE151 /* MovieOverviewViewController.swift */,
+				EA6D28881C9EF49200F06E79 /* LivePhotoSandboxViewController.swift */,
 				EA27F5EE1C98426A00C23F40 /* MovieOverviewControl.swift */,
 				EA6D28861C9EF0FD00F06E79 /* AVKitExtension.swift */,
 				EA379ABA1C68DE6D00106AEF /* Assets.xcassets */,
@@ -312,6 +315,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EA379AB91C68DE6D00106AEF /* AppDelegate.swift in Sources */,
+				EA6D28891C9EF49200F06E79 /* LivePhotoSandboxViewController.swift in Sources */,
 				EA379ADF1C6A33A700106AEF /* QuickTimeMov.swift in Sources */,
 				EA379ADA1C6A283500106AEF /* MovieDocument.swift in Sources */,
 				EA6D28871C9EF0FD00F06E79 /* AVKitExtension.swift in Sources */,


### PR DESCRIPTION
Time to UI update!
- Main playback window (created from Open...)
- Main playback overview window
- Play, seek movie and `Create Live Photo With This Frame` opens LivePhotoSandbox popover
- In LivePhotoSandbox, we can preview 3 secs live photo on click, drag scope around the poster frame, check beginning and ending frame image, and `Create Live Photo` to export to Photos.app with these settings

![screen shot 2016-03-22 at 0 14 06](https://cloud.githubusercontent.com/assets/11156/13923380/c7cf484e-efc3-11e5-8946-fc62c6859c6b.jpg)
