### PR TITLE
Fix oversized live photo sandbox popover

### DIFF
--- a/LoveLiver-osx/LivePhotoSandboxViewController.swift
+++ b/LoveLiver-osx/LivePhotoSandboxViewController.swift
@@ -176,11 +176,11 @@ class LivePhotoSandboxViewController: NSViewController {
             "spacerRR": NSView(),
             ])
         autolayout("H:|-p-[close]-(>=p)-[export]-p-|")
-        autolayout("H:|-p-[player(>=300)]-p-|")
+        autolayout("H:|-p-[player]-p-|")
         autolayout("H:|-p-[startFrame]-(>=p)-[endFrame(==startFrame)]-p-|")
         autolayout("H:|-p-[startLabel][spacerLL][beforePosterLabel][spacerLR(==spacerLL)][posterLabel][spacerRL(==spacerLL)][afterPosterLabel][spacerRR(==spacerLL)][endLabel]-p-|")
         autolayout("H:|-p-[overview]-p-|")
-        autolayout("V:|-p-[export]-p-[player(>=300)]")
+        autolayout("V:|-p-[export]-p-[player]")
         autolayout("V:|-p-[close]-p-[player]")
         autolayout("V:[player][overview(==64)]")
         autolayout("V:[overview]-p-[startFrame(==128)][startLabel]-p-|")


### PR DESCRIPTION
fixes #9.

currently playerview uses `>= 300` constraint. this make movie height `>= 534` with iPhone 4.7 inch portrait movies (750x1334).
typical 12inch or 13inch displays does not have a room for these size of view contained in its popover.